### PR TITLE
Switch to JWT Access tokens.

### DIFF
--- a/server.js
+++ b/server.js
@@ -65,6 +65,9 @@ const oidcConfig = {
     ],
   },
   responseTypes: ['id_token token', 'code'],
+  formats: {
+    AccessToken: 'jwt',
+  },
   clients: clientConfigs.map(clientConfig => ({
     client_id: clientConfig.clientId,
     redirect_uris: clientConfig.redirect_uris,


### PR DESCRIPTION
The previous opaque token didn't work with our gateway anyway. "The mapper [org.gridsuite.gateway.GatewayService$$Lambda/0x00007581b66b4f78] returned a null value."

The jwt token is validated by our gateway. It looks like this {
  "jti": "HipmvWWhfZIRJg33IYqym",
  "sub": "XXX",
  "iat": 1747236299,
  "exp": 1747239899,
  "scope": "openid",
  "iss": "http://172.17.0.1:9090/",
  "aud": "gridexplore-client"
}